### PR TITLE
[takea-look#34] 스티커 목록에서 탭전환을 여러번 수행하다보면 앱이 프리징되는 이슈 수정

### DIFF
--- a/core/presentation/src/main/kotlin/my/takealook/presentation/MviViewModel.kt
+++ b/core/presentation/src/main/kotlin/my/takealook/presentation/MviViewModel.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.stateIn
 abstract class MviViewModel<ACTION : UiAction, STATE : UiState, EFFECT : SideEffect>(
     initialState: STATE
 ): ViewModel() {
-    private val actionChannel = Channel<ACTION>(Channel.Factory.BUFFERED)
-    private val effectChannel = Channel<EFFECT>(Channel.Factory.BUFFERED)
+    private val actionChannel = Channel<ACTION>(Channel.Factory.CONFLATED)
+    private val effectChannel = Channel<EFFECT>(Channel.Factory.CONFLATED)
 
     val effect = effectChannel
         .receiveAsFlow()


### PR DESCRIPTION
[takea-look#34] Channel Buffered -> Conflated 변경

fixed #34


## 이슈 내용 
스티커 목록에서 탭전환을 여러번 수행하다보면, 앱이 프리징되는 이슈가 있었음 

## 수정 내용 
Channel 특성상 이벤트가 Buffer의 용량을 초과하려하면 버퍼를 소비할때까지 suspend 되는 백프래셔(backpressure) 의 특성을 띠고 있다.
이때 `effectChannel` 을 사용하지 않고 있기 때문에 이벤트는 기본 버퍼인 64를 넘고 있었고, 이를 버퍼 사이즈를 1만 남기고 Overflow되면 가장 오래된것을 삭제하는 `CONFLATED` 전략을 적용하였다.

사실 effectFlow를 쓰는 사용사례는 Toast 정도가 있는데 앱사용 사례로 미루어 보았을 때, 여러 이벤트를 모아두었다가 한꺼번에 처리할만한 수요가 존재하지않았다. 대부분 실시간으로 이벤트를 Consume하면서 사이드이펙트를 처리해야했다. 그렇기에 CONFLATED가 적합하다고 판단이 들었다.

해당 화면에서 이 이슈가 발생된 이유는 단순히 TOAST, SNACKBAR 같은 Composable SideEffect 처리관련한 이벤트를 사용하지 않았기 때문이다.